### PR TITLE
cobol-promises 1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 [![cobol-promises](http://i.imgur.com/DfsVV3F.png)](#)
 
-# cobol-promises [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/cobol-promises.svg)](https://www.npmjs.com/package/cobol-promises) [![Downloads](https://img.shields.io/npm/dt/cobol-promises.svg)](https://www.npmjs.com/package/cobol-promises) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# cobol-promises
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/cobol-promises.svg)](https://www.npmjs.com/package/cobol-promises) [![Downloads](https://img.shields.io/npm/dt/cobol-promises.svg)](https://www.npmjs.com/package/cobol-promises) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > COBOL bridge for NodeJS with promises support.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cobol-promises",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "COBOL bridge for NodeJS with promises support.",
   "main": "lib/index.js",
   "keywords": [
@@ -44,6 +44,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
